### PR TITLE
Node-Media-Server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # nginx-obs-automatic-low-bitrate-switching
 
-Simple app to automatically switch scenes in OBS based on the current bitrate fetched from the NGINX stats page.
+Simple app to automatically switch scenes in OBS based on the current bitrate fetched from an RTMP server's stats page.
 
 Don't feel like setting this all up by yourself? Check out these links for similar solutions!
 
@@ -21,17 +21,23 @@ Don't feel like setting this all up by yourself? Check out these links for simil
 -   [Git](http://git-scm.com/)
 -   [Node.js](http://nodejs.org/) (with NPM)
 
-> This script uses OBS plugin "obs-websocket" inconjuction with "OBS-Studio" and "NGINX-RTMP" (see links below).
+> This script uses OBS plugin "obs-websocket" inconjuction with "OBS-Studio". For monitoring "NGINX-RTMP" (see links below).
 
--   [NGINX-RTMP](https://github.com/arut/nginx-rtmp-module/)
 -   [OBS-Studio](https://github.com/obsproject/obs-studio/)
 -   [OBS-WEBSOCKET](https://github.com/Palakis/obs-websocket/)
+
+> It supports monitoring streams on either NGINX-RTMP server or Node-Media-Server.
+
+-   [NGINX-RTMP](https://github.com/arut/nginx-rtmp-module/)
+-   [Node-Media-Server](https://github.com/illuspas/Node-Media-Server/)
 
 ## Installation from Source
 
 -   `git clone <repository-url>` or download from [RELEASES](https://github.com/715209/nginx-obs-automatic-low-bitrate-switching/releases)
 -   Change into the new directory.
 -   `npm install --production`
+
+If using NGINX-RTMP server
 -   Replace your `nginx.conf` with the one given here.
 -   Put `stat.xsl` in your nginx folder.
 
@@ -89,6 +95,18 @@ You can also enable/disable certain features from chat, see below:
 > |    Admins    | !mod (on/off)      | enables/disables the use of MOD commands.                  | !mod on      |
 > |    Admins    | !notify (on/off)   | enables/disables the notifications in chat.                | !notify off  |
 > |    Admins    | !autostop (on/off) | enables/disables the auto stop feature when you host/raid. | !autostop on |
+
+## Running with Node-Media-Server
+Modify the RTMP section in config.json like this to connect to a node-media-server running externally:
+
+```
+    "rtmp": {
+        "server": "node-media-server",
+        "stats": "http://localhost:8000/api/streams",
+        "application": "publish",
+        "key": "live"
+    }
+```
 
 ## Help it won't change scenes
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Don't feel like setting this all up by yourself? Check out these links for simil
 -   [OBS-Studio](https://github.com/obsproject/obs-studio/)
 -   [OBS-WEBSOCKET](https://github.com/Palakis/obs-websocket/)
 
-> It supports monitoring streams on either NGINX-RTMP server or Node-Media-Server.
+> It supports monitoring streams on either NGINX-RTMP server or Node-Media-Server. Node-Media-Server is also built into NOALBS for an easy all-in-one streaming solution.
 
 -   [NGINX-RTMP](https://github.com/arut/nginx-rtmp-module/)
 -   [Node-Media-Server](https://github.com/illuspas/Node-Media-Server/)
@@ -97,6 +97,33 @@ You can also enable/disable certain features from chat, see below:
 > |    Admins    | !autostop (on/off) | enables/disables the auto stop feature when you host/raid. | !autostop on |
 
 ## Running with Node-Media-Server
+### Using the inbuilt server
+Defining a nodeMediaServer block in config.json will enable a fully functional node-media-server RTMP server to accept incoming streams:
+
+```
+    "rtmp": {
+        "application": "publish",
+        "key": "live"
+    },
+    "nodeMediaServer": {
+        "rtmp": {
+            "port": 1935,
+            "chunk_size": 60000,
+            "gop_cache": true,
+            "ping": 30,
+            "ping_timeout": 60
+        },
+        "http": {
+            "port": 8000
+        }
+    }
+```
+
+> The `nodeMediaServer` object is passed directly as the node-media-server configuration, [more details here](https://github.com/illuspas/Node-Media-Server#npm-version-recommended). It will also automatically fill out the rtmp server type and stats fields.
+
+> Note: This is probably best for local connections and testing only unless you [enable authentication](https://github.com/illuspas/Node-Media-Server#authentication)
+
+### Using an external server
 Modify the RTMP section in config.json like this to connect to a node-media-server running externally:
 
 ```

--- a/lib/app.js
+++ b/lib/app.js
@@ -4,6 +4,8 @@ var _ObsSwitcher = _interopRequireDefault(require("./components/ObsSwitcher"));
 
 var _Chat = _interopRequireDefault(require("./components/Chat"));
 
+var _NodeMediaServer = _interopRequireDefault(require("./components/NodeMediaServer"));
+
 var _config = _interopRequireDefault(require("../config"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
@@ -14,3 +16,5 @@ var obs = new _ObsSwitcher.default(_config.default.obs.ip, _config.default.obs.p
 if (_config.default.twitchChat.enable) {
   var chat = new _Chat.default(_config.default.twitchChat.botUsername, _config.default.twitchChat.oauth, _config.default.twitchChat.channel, obs);
 }
+
+var nodeMediaServer = new _NodeMediaServer.default(_config.default.nodeMediaServer, obs);

--- a/lib/components/NodeMediaServer.js
+++ b/lib/components/NodeMediaServer.js
@@ -1,0 +1,50 @@
+"use strict";
+
+var _nodeMediaServer = _interopRequireDefault(require("node-media-server"));
+
+var _signale = _interopRequireDefault(require("signale"));
+
+var _config = _interopRequireDefault(require("../../config"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var NodeMediaServerManager = function NodeMediaServerManager(nmsConfig, obsSwitcher) {
+  _classCallCheck(this, NodeMediaServerManager);
+
+  if (!nmsConfig) {
+    return;
+  }
+
+  console = _signale.default.scope("NMS");
+  this.obsSwitcher = obsSwitcher;
+  this.nodeMediaServer = new _nodeMediaServer.default(nmsConfig);
+  this.nodeMediaServer.run();
+
+  if (_config.default.rtmp && !_config.default.rtmp.stats) {
+    _config.default.rtmp.server = "node-media-server";
+    var auth = "";
+
+    if (nmsConfig.auth && nmsConfig.auth.api) {
+      auth = "".concat(nmsConfig.auth.api_user, ":").concat(nmsConfig.auth.api_pass, "@");
+    }
+
+    if (nmsConfig.http) {
+      _config.default.rtmp.stats = "http://".concat(auth, "localhost:").concat(nmsConfig.http.port, "/api/streams");
+    }
+
+    if (nmsConfig.https) {
+      _config.default.rtmp.stats = "https://".concat(auth, "localhost:").concat(nmsConfig.https.port, "/api/streams");
+    }
+  }
+
+  this.nodeMediaServer.on('postPublish', function (id, StreamPath, args) {
+    obsSwitcher.switchSceneIfNecessary();
+  });
+  this.nodeMediaServer.on('donePublish', function (id, StreamPath, args) {
+    obsSwitcher.switchSceneIfNecessary();
+  });
+};
+
+module.exports = NodeMediaServerManager;

--- a/lib/components/ObsSwitcher.js
+++ b/lib/components/ObsSwitcher.js
@@ -195,7 +195,7 @@ function (_EventEmitter) {
       regeneratorRuntime.mark(function _callee2() {
         var _this2 = this;
 
-        var _config$rtmp, server, stats, application, key, response, data;
+        var _config$rtmp, server, stats, application, key, response, data, _response, _data;
 
         return regeneratorRuntime.wrap(function _callee2$(_context2) {
           while (1) {
@@ -203,7 +203,7 @@ function (_EventEmitter) {
               case 0:
                 _config$rtmp = _config.default.rtmp, server = _config$rtmp.server, stats = _config$rtmp.stats, application = _config$rtmp.application, key = _config$rtmp.key;
                 _context2.t0 = server;
-                _context2.next = _context2.t0 === "nginx" ? 4 : 18;
+                _context2.next = _context2.t0 === "nginx" ? 4 : _context2.t0 === "node-media-server" ? 18 : 32;
                 break;
 
               case 4:
@@ -243,21 +243,45 @@ function (_EventEmitter) {
                 log.error("[NGINX] Error fetching stats");
 
               case 17:
-                return _context2.abrupt("break", 20);
+                return _context2.abrupt("break", 34);
 
               case 18:
-                log.error("[STATS] Something went wrong at getting the RTMP server, did you enter the correct name in the config?");
-                return _context2.abrupt("break", 20);
-
-              case 20:
-                return _context2.abrupt("return", this.bitrate);
+                _context2.prev = 18;
+                _context2.next = 21;
+                return (0, _nodeFetch.default)("".concat(stats, "/").concat(application, "/").concat(key));
 
               case 21:
+                _response = _context2.sent;
+                _context2.next = 24;
+                return _response.json();
+
+              case 24:
+                _data = _context2.sent;
+                this.bitrate = _data.bitrate || null;
+                _context2.next = 31;
+                break;
+
+              case 28:
+                _context2.prev = 28;
+                _context2.t2 = _context2["catch"](18);
+                log.error("[NMS] Error fetching stats, is the API http server running?");
+
+              case 31:
+                return _context2.abrupt("break", 34);
+
+              case 32:
+                log.error("[STATS] Something went wrong at getting the RTMP server, did you enter the correct name in the config?");
+                return _context2.abrupt("break", 34);
+
+              case 34:
+                return _context2.abrupt("return", this.bitrate);
+
+              case 35:
               case "end":
                 return _context2.stop();
             }
           }
-        }, _callee2, this, [[4, 14]]);
+        }, _callee2, this, [[4, 14], [18, 28]]);
       }));
 
       function getBitrate() {

--- a/lib/components/ObsSwitcher.js
+++ b/lib/components/ObsSwitcher.js
@@ -108,27 +108,18 @@ function (_EventEmitter) {
   }
 
   _createClass(ObsSwitcher, [{
-    key: "onAuth",
-    value: function onAuth() {
-      var _this2 = this;
-
-      log.success("Successfully connected");
-      this.obs.SetHeartbeat({
-        enable: true
-      });
-      this.getSceneList();
-      this.interval = setInterval(
-      /*#__PURE__*/
-      _asyncToGenerator(
+    key: "switchSceneIfNecessary",
+    value: function () {
+      var _switchSceneIfNecessary = _asyncToGenerator(
       /*#__PURE__*/
       regeneratorRuntime.mark(function _callee() {
-        var bitrate, _ref2, currentScene, canSwitch;
+        var bitrate, _ref, currentScene, canSwitch;
 
         return regeneratorRuntime.wrap(function _callee$(_context) {
           while (1) {
             switch (_context.prev = _context.next) {
               case 0:
-                if (!(!_this2.obsStreaming && (_config.default.obs.onlySwitchWhenStreaming == null || _config.default.obs.onlySwitchWhenStreaming))) {
+                if (!(!this.obsStreaming && (_config.default.obs.onlySwitchWhenStreaming == null || _config.default.obs.onlySwitchWhenStreaming))) {
                   _context.next = 2;
                   break;
                 }
@@ -137,32 +128,32 @@ function (_EventEmitter) {
 
               case 2:
                 _context.next = 4;
-                return _this2.getBitrate();
+                return this.getBitrate();
 
               case 4:
                 bitrate = _context.sent;
                 _context.next = 7;
-                return _this2.canSwitch();
+                return this.canSwitch();
 
               case 7:
-                _ref2 = _context.sent;
-                currentScene = _ref2.currentScene;
-                canSwitch = _ref2.canSwitch;
+                _ref = _context.sent;
+                currentScene = _ref.currentScene;
+                canSwitch = _ref.canSwitch;
 
                 if (bitrate !== null) {
-                  _this2.isLive = true;
-                  _this2.isLive && canSwitch && (bitrate === 0 && currentScene.name !== _this2.previousScene && (_this2.obs.setCurrentScene({
-                    "scene-name": _this2.previousScene
-                  }), _this2.switchSceneEmit("live", _this2.previousScene), log.info("Stream went online switching to scene: \"".concat(_this2.previousScene, "\""))), bitrate <= _this2.lowBitrateTrigger && currentScene.name !== _this2.lowBitrateScene && bitrate !== 0 && (_this2.obs.setCurrentScene({
-                    "scene-name": _this2.lowBitrateScene
-                  }), _this2.previousScene = _this2.lowBitrateScene, _this2.switchSceneEmit("lowBitrateScene"), log.info("Low bitrate detected switching to scene: \"".concat(_this2.lowBitrateScene, "\""))), bitrate > _this2.lowBitrateTrigger && currentScene.name !== _this2.normalScene && (_this2.obs.setCurrentScene({
-                    "scene-name": _this2.normalScene
-                  }), _this2.previousScene = _this2.normalScene, _this2.switchSceneEmit("normalScene"), log.info("Switching to normal scene: \"".concat(_this2.normalScene, "\""))));
+                  this.isLive = true;
+                  this.isLive && canSwitch && (bitrate === 0 && currentScene.name !== this.previousScene && (this.obs.setCurrentScene({
+                    "scene-name": this.previousScene
+                  }), this.switchSceneEmit("live", this.previousScene), log.info("Stream went online switching to scene: \"".concat(this.previousScene, "\""))), bitrate <= this.lowBitrateTrigger && currentScene.name !== this.lowBitrateScene && bitrate !== 0 && (this.obs.setCurrentScene({
+                    "scene-name": this.lowBitrateScene
+                  }), this.previousScene = this.lowBitrateScene, this.switchSceneEmit("lowBitrateScene"), log.info("Low bitrate detected switching to scene: \"".concat(this.lowBitrateScene, "\""))), bitrate > this.lowBitrateTrigger && currentScene.name !== this.normalScene && (this.obs.setCurrentScene({
+                    "scene-name": this.normalScene
+                  }), this.previousScene = this.normalScene, this.switchSceneEmit("normalScene"), log.info("Switching to normal scene: \"".concat(this.normalScene, "\""))));
                 } else {
-                  _this2.isLive = false;
-                  canSwitch && currentScene.name !== _this2.offlineScene && (_this2.obs.setCurrentScene({
-                    "scene-name": _this2.offlineScene
-                  }), _this2.switchSceneEmit("offlineScene"), _this2.streamStatus = null, log.warn("Error receiving current bitrate or stream is offline. Switching to offline scene: \"".concat(_this2.offlineScene, "\"")));
+                  this.isLive = false;
+                  canSwitch && currentScene.name !== this.offlineScene && (this.obs.setCurrentScene({
+                    "scene-name": this.offlineScene
+                  }), this.switchSceneEmit("offlineScene"), this.streamStatus = null, log.warn("Error receiving current bitrate or stream is offline. Switching to offline scene: \"".concat(this.offlineScene, "\"")));
                 }
 
               case 11:
@@ -171,7 +162,23 @@ function (_EventEmitter) {
             }
           }
         }, _callee, this);
-      })), _config.default.obs.requestMs);
+      }));
+
+      function switchSceneIfNecessary() {
+        return _switchSceneIfNecessary.apply(this, arguments);
+      }
+
+      return switchSceneIfNecessary;
+    }()
+  }, {
+    key: "onAuth",
+    value: function onAuth() {
+      log.success("Successfully connected");
+      this.obs.SetHeartbeat({
+        enable: true
+      });
+      this.getSceneList();
+      this.interval = setInterval(this.switchSceneIfNecessary.bind(this), _config.default.obs.requestMs);
     }
   }, {
     key: "switchSceneEmit",
@@ -186,7 +193,7 @@ function (_EventEmitter) {
       var _getBitrate = _asyncToGenerator(
       /*#__PURE__*/
       regeneratorRuntime.mark(function _callee2() {
-        var _this3 = this;
+        var _this2 = this;
 
         var _config$rtmp, server, stats, application, key, response, data;
 
@@ -217,14 +224,14 @@ function (_EventEmitter) {
                   }).live[0].stream;
 
                   if (publish == null) {
-                    _this3.nginxVideoMeta = null;
-                    _this3.bitrate = null;
+                    _this2.nginxVideoMeta = null;
+                    _this2.bitrate = null;
                   } else {
                     var stream = publish.find(function (stream) {
                       return stream.name[0] === key;
                     });
-                    _this3.nginxVideoMeta = stream.meta[0].video[0];
-                    _this3.bitrate = Math.round(stream.bw_video[0] / 1024);
+                    _this2.nginxVideoMeta = stream.meta[0].video[0];
+                    _this2.bitrate = Math.round(stream.bw_video[0] / 1024);
                   }
                 });
                 _context2.next = 17;
@@ -284,13 +291,13 @@ function (_EventEmitter) {
   }, {
     key: "reconnect",
     value: function reconnect() {
-      var _this4 = this;
+      var _this3 = this;
 
       log.info("Trying to reconnect in 5 seconds");
       setTimeout(function () {
-        _this4.obs.connect({
-          address: _this4.address,
-          password: _this4.password
+        _this3.obs.connect({
+          address: _this3.address,
+          password: _this3.password
         }).catch(function (e) {// handle this somewhere else
         });
       }, 5000);
@@ -301,7 +308,7 @@ function (_EventEmitter) {
       var _streamStopped = _asyncToGenerator(
       /*#__PURE__*/
       regeneratorRuntime.mark(function _callee3() {
-        var _ref3, canSwitch;
+        var _ref2, canSwitch;
 
         return regeneratorRuntime.wrap(function _callee3$(_context3) {
           while (1) {
@@ -314,8 +321,8 @@ function (_EventEmitter) {
                 return this.canSwitch();
 
               case 5:
-                _ref3 = _context3.sent;
-                canSwitch = _ref3.canSwitch;
+                _ref2 = _context3.sent;
+                canSwitch = _ref2.canSwitch;
 
                 if (canSwitch) {
                   this.obs.setCurrentScene({

--- a/package-lock.json
+++ b/package-lock.json
@@ -817,6 +817,15 @@
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
             "dev": true
         },
+        "accepts": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+            "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+            "requires": {
+                "mime-types": "~2.1.24",
+                "negotiator": "0.6.2"
+            }
+        },
         "ansi-align": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -878,6 +887,11 @@
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
             "dev": true
+        },
+        "array-flatten": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+            "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
         },
         "array-unique": {
             "version": "0.3.2",
@@ -995,11 +1009,43 @@
                 }
             }
         },
+        "basic-auth-connect": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
+            "integrity": "sha1-/bC0OWLKe0BFanwrtI/hc9otISI="
+        },
         "binary-extensions": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
             "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
             "dev": true
+        },
+        "body-parser": {
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+            "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+            "requires": {
+                "bytes": "3.1.0",
+                "content-type": "~1.0.4",
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "http-errors": "1.7.2",
+                "iconv-lite": "0.4.24",
+                "on-finished": "~2.3.0",
+                "qs": "6.7.0",
+                "raw-body": "2.4.0",
+                "type-is": "~1.6.17"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
         },
         "boxen": {
             "version": "1.3.0",
@@ -1071,6 +1117,11 @@
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
             "dev": true
+        },
+        "bytes": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+            "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
         },
         "cache-base": {
             "version": "1.0.1",
@@ -1233,6 +1284,19 @@
                 "xdg-basedir": "^3.0.0"
             }
         },
+        "content-disposition": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+            "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+            "requires": {
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "content-type": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+        },
         "convert-source-map": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -1241,6 +1305,16 @@
             "requires": {
                 "safe-buffer": "~5.1.1"
             }
+        },
+        "cookie": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+            "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+        },
+        "cookie-signature": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
         },
         "copy-descriptor": {
             "version": "0.1.1",
@@ -1284,6 +1358,11 @@
             "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
             "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
             "dev": true
+        },
+        "dateformat": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+            "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
         },
         "debug": {
             "version": "3.1.0",
@@ -1346,6 +1425,16 @@
                 }
             }
         },
+        "depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+        },
+        "destroy": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+        },
         "dot-prop": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
@@ -1361,11 +1450,21 @@
             "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
             "dev": true
         },
+        "ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+        },
         "electron-to-chromium": {
             "version": "1.3.96",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.96.tgz",
             "integrity": "sha512-ZUXBUyGLeoJxp4Nt6G/GjBRLnyz8IKQGexZ2ndWaoegThgMGFO1tdDYID5gBV32/1S83osjJHyfzvanE/8HY4Q==",
             "dev": true
+        },
+        "encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
         },
         "error-ex": {
             "version": "1.3.2",
@@ -1374,6 +1473,11 @@
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
+        },
+        "escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
         },
         "escape-string-regexp": {
             "version": "1.0.5",
@@ -1385,6 +1489,11 @@
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
+        },
+        "etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
         },
         "execa": {
             "version": "0.7.0",
@@ -1441,6 +1550,53 @@
                     "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "express": {
+            "version": "4.17.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+            "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+            "requires": {
+                "accepts": "~1.3.7",
+                "array-flatten": "1.1.1",
+                "body-parser": "1.19.0",
+                "content-disposition": "0.5.3",
+                "content-type": "~1.0.4",
+                "cookie": "0.4.0",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "finalhandler": "~1.1.2",
+                "fresh": "0.5.2",
+                "merge-descriptors": "1.0.1",
+                "methods": "~1.1.2",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.3",
+                "path-to-regexp": "0.1.7",
+                "proxy-addr": "~2.0.5",
+                "qs": "6.7.0",
+                "range-parser": "~1.2.1",
+                "safe-buffer": "5.1.2",
+                "send": "0.17.1",
+                "serve-static": "1.14.1",
+                "setprototypeof": "1.1.1",
+                "statuses": "~1.5.0",
+                "type-is": "~1.6.18",
+                "utils-merge": "1.0.1",
+                "vary": "~1.1.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
                     }
                 }
             }
@@ -1570,6 +1726,30 @@
                 }
             }
         },
+        "finalhandler": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+            "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+            "requires": {
+                "debug": "2.6.9",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.3",
+                "statuses": "~1.5.0",
+                "unpipe": "~1.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "find-cache-dir": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
@@ -1595,6 +1775,11 @@
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
         },
+        "forwarded": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+            "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+        },
         "fragment-cache": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -1603,6 +1788,11 @@
             "requires": {
                 "map-cache": "^0.2.2"
             }
+        },
+        "fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
         },
         "fs-readdir-recursive": {
             "version": "1.1.0",
@@ -2310,6 +2500,26 @@
                 "parse-passwd": "^1.0.0"
             }
         },
+        "http-errors": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+            "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+            "requires": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.1",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.0"
+            }
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
         "ignore-by-default": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
@@ -2357,6 +2567,11 @@
             "requires": {
                 "loose-envify": "^1.0.0"
             }
+        },
+        "ipaddr.js": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+            "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
         },
         "is-accessor-descriptor": {
             "version": "0.1.6",
@@ -2651,8 +2866,7 @@
         "lodash": {
             "version": "4.17.15",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-            "dev": true
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "loose-envify": {
             "version": "1.4.0",
@@ -2703,6 +2917,21 @@
                 "object-visit": "^1.0.0"
             }
         },
+        "media-typer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+        },
+        "merge-descriptors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+        },
+        "methods": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+        },
         "micromatch": {
             "version": "3.1.10",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -2722,6 +2951,24 @@
                 "regex-not": "^1.0.0",
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.2"
+            }
+        },
+        "mime": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+        },
+        "mime-db": {
+            "version": "1.40.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+            "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+        },
+        "mime-types": {
+            "version": "2.1.24",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+            "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+            "requires": {
+                "mime-db": "1.40.0"
             }
         },
         "minimatch": {
@@ -2764,7 +3011,6 @@
             "version": "0.5.1",
             "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
             "requires": {
                 "minimist": "0.0.8"
             },
@@ -2772,8 +3018,7 @@
                 "minimist": {
                     "version": "0.0.8",
                     "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "dev": true
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                 }
             }
         },
@@ -2808,10 +3053,49 @@
                 "to-regex": "^3.0.1"
             }
         },
+        "negotiator": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+            "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+        },
         "node-fetch": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
             "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+        },
+        "node-media-server": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/node-media-server/-/node-media-server-2.1.4.tgz",
+            "integrity": "sha512-3+6aWrExhZwT70U9Bjgq/dLDo22NcKql/nOCwbJ3BuZDgE8oBe5PkCSpCHyfES2o6vC2pTTvAojIO+bdRcC5cg==",
+            "requires": {
+                "basic-auth-connect": "^1.0.0",
+                "chalk": "^2.4.2",
+                "dateformat": "^3.0.3",
+                "express": "^4.16.4",
+                "lodash": ">=4.17.13",
+                "mkdirp": "^0.5.1",
+                "ws": "^5.2.2"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "ws": {
+                    "version": "5.2.2",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+                    "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+                    "requires": {
+                        "async-limiter": "~1.0.0"
+                    }
+                }
+            }
         },
         "node-modules-regexp": {
             "version": "1.0.0",
@@ -2940,6 +3224,14 @@
                 }
             }
         },
+        "on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "requires": {
+                "ee-first": "1.1.1"
+            }
+        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3019,6 +3311,11 @@
             "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
             "dev": true
         },
+        "parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+        },
         "pascalcase": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -3059,6 +3356,11 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
             "dev": true
+        },
+        "path-to-regexp": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
         },
         "pify": {
             "version": "3.0.0",
@@ -3116,6 +3418,15 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
+        "proxy-addr": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+            "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+            "requires": {
+                "forwarded": "~0.1.2",
+                "ipaddr.js": "1.9.0"
+            }
+        },
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -3127,6 +3438,27 @@
             "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.6.tgz",
             "integrity": "sha512-NdF35+QsqD7EgNEI5mkI/X+UwaxVEbQaz9f4IooEmMUv6ZPmlTQYGjBPJGgrlzNdjSvIy4MWMg6Q6vCgBO2K+w==",
             "dev": true
+        },
+        "qs": {
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+            "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        },
+        "range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+        },
+        "raw-body": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+            "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+            "requires": {
+                "bytes": "3.1.0",
+                "http-errors": "1.7.2",
+                "iconv-lite": "0.4.24",
+                "unpipe": "1.0.0"
+            }
         },
         "rc": {
             "version": "1.2.8",
@@ -3314,6 +3646,11 @@
                 "ret": "~0.1.10"
             }
         },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -3332,6 +3669,59 @@
             "dev": true,
             "requires": {
                 "semver": "^5.0.3"
+            }
+        },
+        "send": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+            "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+            "requires": {
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "~1.7.2",
+                "mime": "1.6.0",
+                "ms": "2.1.1",
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.1",
+                "statuses": "~1.5.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                        }
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+                }
+            }
+        },
+        "serve-static": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+            "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+            "requires": {
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.3",
+                "send": "0.17.1"
             }
         },
         "set-value": {
@@ -3356,6 +3746,11 @@
                     }
                 }
             }
+        },
+        "setprototypeof": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+            "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
         },
         "sha.js": {
             "version": "2.4.11",
@@ -3592,6 +3987,11 @@
                 }
             }
         },
+        "statuses": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        },
         "string-template": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz",
@@ -3718,6 +4118,11 @@
                 "repeat-string": "^1.6.1"
             }
         },
+        "toidentifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+            "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+        },
         "touch": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -3732,6 +4137,15 @@
             "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
             "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
             "dev": true
+        },
+        "type-is": {
+            "version": "1.6.18",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+            "requires": {
+                "media-typer": "0.3.0",
+                "mime-types": "~2.1.24"
+            }
         },
         "undefsafe": {
             "version": "2.0.2",
@@ -3810,6 +4224,11 @@
             "requires": {
                 "crypto-random-string": "^1.0.0"
             }
+        },
+        "unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
         },
         "unset-value": {
             "version": "1.0.0",
@@ -3908,6 +4327,11 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
         },
+        "utils-merge": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+        },
         "v8flags": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.2.tgz",
@@ -3916,6 +4340,11 @@
             "requires": {
                 "homedir-polyfill": "^1.0.1"
             }
+        },
+        "vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
         },
         "which": {
             "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "fast-fuzzy": "^1.8.4",
         "node-fetch": "^2.3.0",
+        "node-media-server": "^2.1.4",
         "obs-websocket-js": "^1.2.0",
         "signale": "^1.3.0",
         "string-template": "^1.0.0",

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 import ObsSwitcher from "./components/ObsSwitcher";
 import Chat from "./components/Chat";
+import NodeMediaServer from "./components/NodeMediaServer";
 import config from "../config";
 
 console.log(`
@@ -23,3 +24,5 @@ const obs = new ObsSwitcher(
 if (config.twitchChat.enable) {
     const chat = new Chat(config.twitchChat.botUsername, config.twitchChat.oauth, config.twitchChat.channel, obs);
 }
+
+const nodeMediaServer = new NodeMediaServer(config.nodeMediaServer, obs);

--- a/src/components/NodeMediaServer.js
+++ b/src/components/NodeMediaServer.js
@@ -1,0 +1,46 @@
+import NodeMediaServer from 'node-media-server';
+import signale from "signale";
+import config from "../../config";
+
+class NodeMediaServerManager {
+    constructor(nmsConfig, obsSwitcher) {
+        if (!nmsConfig) {
+            return;
+        }
+
+        console = signale.scope("NMS");
+
+        this.obsSwitcher = obsSwitcher;
+
+        this.nodeMediaServer = new NodeMediaServer(nmsConfig);
+        this.nodeMediaServer.run();
+
+        if (config.rtmp && !config.rtmp.stats) {
+            config.rtmp.server = "node-media-server";
+
+            let auth = "";
+
+            if (nmsConfig.auth && nmsConfig.auth.api) {
+                auth = `${nmsConfig.auth.api_user}:${nmsConfig.auth.api_pass}@`;
+            }
+
+            if (nmsConfig.http) {
+                config.rtmp.stats = `http://${auth}localhost:${nmsConfig.http.port}/api/streams`;
+            }
+            
+            if (nmsConfig.https) {
+                config.rtmp.stats = `https://${auth}localhost:${nmsConfig.https.port}/api/streams`;
+            }
+        }
+
+        this.nodeMediaServer.on('postPublish', (id, StreamPath, args) => {
+            obsSwitcher.switchSceneIfNecessary();
+        });
+
+        this.nodeMediaServer.on('donePublish', (id, StreamPath, args) => {
+            obsSwitcher.switchSceneIfNecessary();
+        });
+    }
+}
+
+module.exports = NodeMediaServerManager;

--- a/src/components/ObsSwitcher.js
+++ b/src/components/ObsSwitcher.js
@@ -141,6 +141,17 @@ class ObsSwitcher extends EventEmitter {
                     log.error("[NGINX] Error fetching stats");
                 }
                 break;
+            
+            case "node-media-server":
+                try {
+                    const response = await fetch(`${stats}/${application}/${key}`);
+                    const data = await response.json();
+
+                    this.bitrate = data.bitrate || null;
+                } catch (e) {
+                    log.error("[NMS] Error fetching stats, is the API http server running?");
+                }
+                break;
 
             default:
                 log.error("[STATS] Something went wrong at getting the RTMP server, did you enter the correct name in the config?");


### PR DESCRIPTION
This PR adds support to monitor a [Node-Media-Server](https://github.com/illuspas/Node-Media-Server) RTMP server (instead of just nginx).

It also bundles node-media-server into NOALBS and starts it if explicitly enabled, so basically all you need to run a stream now is NOALBS! It will start if if there's a `nodeMediaServer` configuration block, which it will pass directly to Node-Media-Server as its configuration.

- NMS doesn't support dropping subscribers (only publishers), so `!fix` doesn't work, but everything else should be fine
- The http API server port needs to be manually defined in the `nodeMediaServer` configuration for the NMS stats page to work
- The NMS logging is a bit crazy - it repeats the timestamps etc but I tried to integrate it into signale at least a little (open to ideas?)