### PR TITLE
changed path to config.json in Chat.js handleWriteToConfig

### DIFF
--- a/lib/components/Chat.js
+++ b/lib/components/Chat.js
@@ -760,7 +760,7 @@ function () {
   }, {
     key: "handleWriteToConfig",
     value: function handleWriteToConfig() {
-      _fs.default.writeFile('config.json', JSON.stringify(_config.default, null, 4), function (err) {
+      _fs.default.writeFile("".concat(__dirname, "/../../config.json"), JSON.stringify(_config.default, null, 4), function (err) {
         if (err) log.error(err);
       });
     }

--- a/lib/components/Chat.js
+++ b/lib/components/Chat.js
@@ -760,7 +760,7 @@ function () {
   }, {
     key: "handleWriteToConfig",
     value: function handleWriteToConfig() {
-      _fs.default.writeFile('"../../config.json', JSON.stringify(_config.default, null, 4), function (err) {
+      _fs.default.writeFile('config.json', JSON.stringify(_config.default, null, 4), function (err) {
         if (err) log.error(err);
       });
     }

--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -548,6 +548,7 @@ class Chat {
 
     handleWriteToConfig() {
         fs.writeFile('config.json', JSON.stringify(config, null, 4), err => {
+        fs.writeFile(`${__dirname}/../../config.json`, JSON.stringify(config, null, 4), (err) => {
             if (err) log.error(err);
         });
     }

--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -547,7 +547,7 @@ class Chat {
     }
 
     handleWriteToConfig() {
-        fs.writeFile('"../../config.json', JSON.stringify(config, null, 4), err => {
+        fs.writeFile('config.json', JSON.stringify(config, null, 4), err => {
             if (err) log.error(err);
         });
     }


### PR DESCRIPTION
The path is relative to the directory where node was started. This should fix #26 

Tested on windows 10 and debian 10
