### PR TITLE
Fix 'TypeError: Cannot set property console of #<Object> which has only a getter' on node 8

### DIFF
--- a/lib/components/NodeMediaServer.js
+++ b/lib/components/NodeMediaServer.js
@@ -22,7 +22,7 @@ var NodeMediaServerManager = function NodeMediaServerManager(nmsConfig, obsSwitc
   } catch (e) {
     console.log = _signale.default.scope("NMS").log;
 
-    _signale.default.scope("NMS").warn("Couldn't set console for node-media-server. Consider upgrading to node 10 or higher to resovle this problem (error: ".concat(e, ")"));
+    _signale.default.scope("NMS").warn("Couldn't set console for node-media-server. Consider upgrading to node 10 or higher to resolve this problem (error: ".concat(e, ")"));
   }
 
   this.obsSwitcher = obsSwitcher;

--- a/lib/components/NodeMediaServer.js
+++ b/lib/components/NodeMediaServer.js
@@ -17,7 +17,14 @@ var NodeMediaServerManager = function NodeMediaServerManager(nmsConfig, obsSwitc
     return;
   }
 
-  console = _signale.default.scope("NMS");
+  try {
+    console = _signale.default.scope("NMS");
+  } catch (e) {
+    console.log = _signale.default.scope("NMS").log;
+
+    _signale.default.scope("NMS").warn("Couldn't set console for node-media-server. Consider upgrading to node 10 or higher to resovle this problem (error: ".concat(e, ")"));
+  }
+
   this.obsSwitcher = obsSwitcher;
   this.nodeMediaServer = new _nodeMediaServer.default(nmsConfig);
   this.nodeMediaServer.run();

--- a/src/components/NodeMediaServer.js
+++ b/src/components/NodeMediaServer.js
@@ -8,7 +8,12 @@ class NodeMediaServerManager {
             return;
         }
 
-        console = signale.scope("NMS");
+        try {
+            console = signale.scope("NMS");
+        } catch(e) {
+            console.log = signale.scope("NMS").log;
+            signale.scope("NMS").warn(`Couldn't set console for node-media-server. Consider upgrading to node 10 or higher to resovle this problem (error: ${e})`);
+        }
 
         this.obsSwitcher = obsSwitcher;
 

--- a/src/components/NodeMediaServer.js
+++ b/src/components/NodeMediaServer.js
@@ -12,7 +12,7 @@ class NodeMediaServerManager {
             console = signale.scope("NMS");
         } catch(e) {
             console.log = signale.scope("NMS").log;
-            signale.scope("NMS").warn(`Couldn't set console for node-media-server. Consider upgrading to node 10 or higher to resovle this problem (error: ${e})`);
+            signale.scope("NMS").warn(`Couldn't set console for node-media-server. Consider upgrading to node 10 or higher to resolve this problem (error: ${e})`);
         }
 
         this.obsSwitcher = obsSwitcher;


### PR DESCRIPTION
Node 8 doesn't let us set the console variable, failing with the above error. Instead, we now just catch the error and set console.log (which it is happy with), since that's all node-media-server seems to use

We also quietly nudge the user to upgrade from nodejs as well, since it is pretty old now ;)

Fixes #30 