### PR TITLE
Bitrate command: print the RTT when it's available

### DIFF
--- a/lib/components/Chat.js
+++ b/lib/components/Chat.js
@@ -377,9 +377,16 @@ class Chat {
 
   bitrate() {
     if (this.obsProps.bitrate != null) {
-      this.say((0, _stringTemplate.default)(this.locale.bitrate.success, {
-        bitrate: this.obsProps.bitrate
-      }));
+      if (this.obsProps.rtt != null && this.locale.bitrate.success_rtt != null) {
+        this.say((0, _stringTemplate.default)(this.locale.bitrate.success_rtt, {
+          bitrate: this.obsProps.bitrate,
+          rtt: this.obsProps.rtt
+        }));
+      } else {
+        this.say((0, _stringTemplate.default)(this.locale.bitrate.success, {
+          bitrate: this.obsProps.bitrate
+        }));
+      }
     } else {
       this.say(this.locale.bitrate.error);
     }

--- a/locales/de.json
+++ b/locales/de.json
@@ -12,6 +12,7 @@
         "error": "Keine Szene angegeben"
     },
     "bitrate": {
+        "success_rtt": "Aktuelle Bitrate: {bitrate} Kbps, RTT {rtt} ms",
         "success": "Aktuelle Bitrate: {bitrate} Kbps",
         "error": "Aktuelle Bitrate: Offline"
     },

--- a/locales/en.json
+++ b/locales/en.json
@@ -12,6 +12,7 @@
         "error": "No scene specified"
     },
     "bitrate": {
+        "success_rtt": "Current bitrate: {bitrate} Kbps, RTT {rtt} ms",
         "success": "Current bitrate: {bitrate} Kbps",
         "error": "Current bitrate: offline"
     },

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -12,6 +12,7 @@
 		"error": "Ошибка: сцена не указана"
 	},
 	"bitrate": {
+		"success_rtt": "Текущий битрейт: {bitrate} kbps, RTT {rtt} ms",
 		"success": "Текущий битрейт: {bitrate} kbps",
 		"error": "Текущий битрейт: Не в сети"
 	},

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -12,6 +12,7 @@
         "error": "Sahne belirtilmedi"
     },
     "bitrate": {
+        "success_rtt": "Mevcut bit hızı: {bitrate} Kbps, RTT {rtt} ms",
         "success": "Mevcut bit hızı: {bitrate} Kbps",
         "error": "Mevcut bit hızı: çevrimdışı"
     },

--- a/locales/zh_tw.json
+++ b/locales/zh_tw.json
@@ -12,6 +12,7 @@
         "error": "沒有指定場景"
     },
     "bitrate": {
+        "success_rtt": "目前位元率: {bitrate} Kbps, RTT {rtt} ms",
         "success": "目前位元率: {bitrate} Kbps",
         "error": "目前位元率: 離線"
     },

--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -373,11 +373,20 @@ class Chat {
 
     bitrate() {
         if (this.obsProps.bitrate != null) {
-            this.say(
-                format(this.locale.bitrate.success, {
-                    bitrate: this.obsProps.bitrate
-                })
-            );
+            if (this.obsProps.rtt != null && this.locale.bitrate.success_rtt != null) {
+                this.say(
+                    format(this.locale.bitrate.success_rtt, {
+                        bitrate: this.obsProps.bitrate,
+                        rtt: this.obsProps.rtt,
+                    })
+                );
+            } else {
+                this.say(
+                    format(this.locale.bitrate.success, {
+                        bitrate: this.obsProps.bitrate,
+                    })
+                );
+           }
         } else {
             this.say(this.locale.bitrate.error);
         }


### PR DESCRIPTION
I no longer have a RTMP setup in place, so it would be best to double check that the bitrate-only message is printed in that case as intended.

~~Note that until the translation is added to the non-English locales, the previous bitrate-only message will always be printed for those languages.~~