### PR TITLE
Added disabled flag to commands

### DIFF
--- a/config.json
+++ b/config.json
@@ -158,17 +158,20 @@
       "Fix": {
         "permission": "Mod",
         "userPermissions": ["715209"],
-        "alias": ["f"]
+        "alias": ["f"],
+        "disabled": false
       },
       "Switch": {
         "permission": "Mod",
         "userPermissions": null,
-        "alias": ["ss"]
+        "alias": ["ss"],
+        "disabled": false
       },
       "Bitrate": {
         "permission": null,
         "userPermissions": null,
-        "alias": ["b"]
+        "alias": ["b"],
+        "disabled": false
       }
     }
   },

--- a/src/chat/chat_handler.rs
+++ b/src/chat/chat_handler.rs
@@ -277,6 +277,25 @@ impl ChatHandler {
     ) -> Option<bool> {
         let state = user.state.read().await;
         let chat = state.config.chat.as_ref()?;
+        let prefix = &chat.prefix;
+        // grab the raw command token (e.g. "!switch" → "switch")
+        let raw = msg.message.split_whitespace().next().unwrap_or("");
+        if let Some(cmd_str) = raw.strip_prefix(prefix) {
+            let cmd = super::Command::from(cmd_str);
+            let disabled_in_user = chat
+                .commands
+                .as_ref()
+                .and_then(|m| m.get(&cmd))
+                .map_or(false, |info| info.disabled);
+            let disabled_in_default = self
+                .default_commands
+                .get(&cmd)
+                .map_or(false, |info| info.disabled);
+            if disabled_in_user || disabled_in_default {
+                debug!("Command {:?} is disabled, skipping execution", cmd);
+                return Some(false);
+            }
+        }
 
         let chat::CommandPermissions {
             permission,

--- a/src/config.rs
+++ b/src/config.rs
@@ -194,6 +194,7 @@ pub struct CommandInfo {
     pub permission: Option<chat::Permission>,
     pub user_permissions: Option<Vec<String>>,
     pub alias: Option<Vec<String>>,
+    pub disabled: bool,
 }
 
 pub struct File {


### PR DESCRIPTION
We needed to completely disable some commands.
Since this was not possible, I added a flag "disabled" (default false) for commands.

Questions:
Is there a way we could make it so that we do NOT have to change the config.json, because
this PR would be a breaking change for others (they need to add "disabled" to all commands ...)