### PR TITLE
fix: small grammar fix in German localization

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -79,7 +79,7 @@ noalbs:
     retryError: Fehler beim Bearbeiten der Wiederholungsversuche %{count} ist kein gültiger Wert
     retrySuccess: Wiederholungsversuche auf %{count} festgelegt
 scene:
-    success: Zur Szene %{scene} wechseln
+    success: Wechsle auf Szene %{scene}
     error: Keine %{scene}-Szene angegeben
 collection:
     noParams: Keine Szenen-Sammlung angegeben


### PR DESCRIPTION
Fixed a small grammar mistake in the German translation.