### PR TITLE
feat(chat): add disabledCommands and early parser guard

### DIFF
--- a/src/chat/chat_handler.rs
+++ b/src/chat/chat_handler.rs
@@ -249,7 +249,14 @@ impl ChatHandler {
 
         let mut message = msg.message.split_ascii_whitespace();
         let command = message.next().unwrap().strip_prefix(prefix)?;
-        let mut command = super::Command::from(command);
+        
+        // --- Disable via config.json (vor Enum-Mapping/Logging) ---
+        let cmd_lc = command.to_ascii_lowercase();
+        if chat.disabled_commands.iter().any(|c| c == &cmd_lc) {
+            return None;
+        }
+        // --- Ende Guard ---
+let mut command = super::Command::from(command);
 
         if let super::Command::Unknown(ref cmd) = command {
             if let Some(cmd_from_alias) =

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,6 +146,15 @@ pub struct Chat {
     pub enable_auto_stop_stream_on_host_or_raid: bool,
     pub announce_raid_on_auto_stop: bool,
     pub commands: Option<HashMap<chat::Command, CommandInfo>>,
+
+    /// Liste gesperrter Commands (ohne "!", kleingeschrieben)
+    #[serde(
+        default,
+        alias = "disabledCommands",
+        alias = "disabled_commands",
+        alias = "DisabledCommands"
+    )]
+    pub disabled_commands: Vec<String>,
 }
 
 impl Default for Chat {
@@ -161,6 +170,7 @@ impl Default for Chat {
             enable_auto_stop_stream_on_host_or_raid: true,
             announce_raid_on_auto_stop: true,
             commands: None,
+            disabled_commands: Vec::new(),
         }
     }
 }
@@ -255,7 +265,13 @@ impl ConfigLogic for File {
                     .flatten()
                     .for_each(|u| u.make_ascii_lowercase());
             }
-        }
+        
+            // disabledCommands normalisieren & beim Start anzeigen
+            for c in &mut chat.disabled_commands {
+                c.make_ascii_lowercase();
+            }
+            info!("Disabled commands loaded: {:?}", chat.disabled_commands);
+}
 
         Ok(config)
     }


### PR DESCRIPTION
Add support for disabledCommands in config.json to allow disabling specific chat commands via configuration.