### PR TITLE
Add api_key option to SLS stream_server

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,17 @@ So in actuality your 'publisher' is your default `StreamID`, like in the example
 > Switches on low bitrate or high RTT (high RTT seems to be a more accurate way of determining if the stream is bad with this)
 You can change the high RTT trigger value inside config.json:
 
+If you're using the [irl-srt-server](https://github.com/irlserver/irl-srt-server) version of srt-live-server you need to add a [pre-configured](https://github.com/irlserver/irl-srt-server/blob/master/src/sls.conf#L11) `apiKey` for authentication.
+
+```JSON
+"streamServer": {
+  "type": "SrtLiveServer",
+  "statsUrl": "http://localhost:8181/stats",
+  "apiKey": "YOUR_API_KEY"
+  "publisher": "publish/live/feed1"
+}
+```
+
 #### How do I publish to the SLS Server?
 
 see [HERE](https://gitlab.com/mattwb65/srt-live-server#1test-with-ffmpeg)

--- a/src/config.rs
+++ b/src/config.rs
@@ -345,6 +345,7 @@ struct RtmpOld {
     key: Option<String>,
     id: Option<String>,
     publisher: Option<String>,
+    api_key: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -507,6 +508,7 @@ impl From<RtmpOld> for stream_servers::StreamServer {
                     Box::new(stream_servers::sls::SrtLiveServer {
                         stats_url,
                         publisher,
+                        api_key: r.api_key,
                         client: reqwest::Client::new(),
                     })
                 }

--- a/src/stream_servers/sls.rs
+++ b/src/stream_servers/sls.rs
@@ -30,6 +30,8 @@ pub struct SrtLiveServer {
     /// StreamID of the where you are publishing the feed. (ex; publish/live/feed1 )
     pub publisher: String,
 
+    pub api_key: Option<String>,
+
     /// Client to make HTTP requests with
     #[serde(skip, default = "default_reqwest_client")]
     pub client: reqwest::Client,
@@ -37,7 +39,14 @@ pub struct SrtLiveServer {
 
 impl SrtLiveServer {
     pub async fn get_stats(&self) -> Option<Stat> {
-        let res = match self.client.get(&self.stats_url).send().await {
+        let client = &self.client;
+        let mut request = client.get(&self.stats_url);
+
+        if let Some(api_key) = &self.api_key {
+            request = request.header("Authorization", api_key);
+        }
+
+        let res = match request.send().await {
             Ok(res) => res,
             Err(_) => {
                 error!("Stats page ({}) is unreachable", self.stats_url);
@@ -45,8 +54,13 @@ impl SrtLiveServer {
             }
         };
 
-        if res.status() != reqwest::StatusCode::OK {
-            error!("Error accessing stats page ({})", self.stats_url);
+        let response_status = res.status();
+
+        if response_status != reqwest::StatusCode::OK {
+            match response_status {
+                reqwest::StatusCode::UNAUTHORIZED => { error!("Unauthorized (401) access to stats page ({}). Check api_key.", self.stats_url); }
+                _ => { error!("Error accessing stats page ({})", self.stats_url); }
+            }
             return None;
         }
 


### PR DESCRIPTION
I tried to use the https://github.com/irlserver/irl-srt-server as streaming server backend.

It is a fork (of a fork) of the original srt-live-server that is already supported in noalbs, but has more recend development activity. One of the introduced changes is t the need of an API Key to get the stats URL.

* The API Key feature was introduced in this commit https://github.com/rstular/srt-live-server/commit/62a5517cf81e927bcf7138008141c997d576c51b
* The API Key was made madatory in this commit https://github.com/rstular/srt-live-server/commit/eb44fcc2a02ff2aa6007e877d4a33e7850a3f044

As at least some, if not most, of the srt-live-servers are reachable over the internet it is not a bad idea to secure this endpoint with an API key.

I added this feature to noalbs, so the StreamServer `SrtLiveServer` can support an optional api_key.
I also added a more informative log statement if the stats URL returns with a 401 status code to make debugging easier.