### PR TITLE
fix: !fix command now works for rtsp inputs

### DIFF
--- a/src/broadcasting_software/obs_v5.rs
+++ b/src/broadcasting_software/obs_v5.rs
@@ -376,6 +376,7 @@ impl BroadcastingSoftwareLogic for Obsv5 {
                     || m.starts_with("srt")
                     || m.starts_with("udp")
                     || m.starts_with("rist")
+                    || m.starts_with("rtsp")
             }) {
                 continue;
             }


### PR DESCRIPTION
Fixes !fix command for rtsp inputs.

RTSP seems to be the [preferred protocol ](https://mediamtx.org/docs/usage/read#obs-studio) to wire up mediamtx with OBS, thus it would be great if noalbs supported that.