### PR TITLE
fix(refresh): ignore refresh command if already in refresh scene

### DIFF
--- a/src/chat/chat_handler.rs
+++ b/src/chat/chat_handler.rs
@@ -981,6 +981,11 @@ impl DispatchCommand {
             }
         };
         let prev_scene = state.broadcasting_software.current_scene.to_owned();
+        if prev_scene == scene {
+            info!("Skipping refresh - already in refresh scene");
+            return
+        }
+
         drop(state);
 
         self.send(t!("refresh.try", locale = &self.lang)).await;


### PR DESCRIPTION
When the refresh command is executed multiple times concurrently, the previous scene is wrongly assumed to be the refresh scene itself, essentially leading to the switcher being stuck in the refresh scene.