### PR TITLE
fix(stop): more robust obs stream stop

### DIFF
--- a/src/broadcasting_software/obs_v5.rs
+++ b/src/broadcasting_software/obs_v5.rs
@@ -327,13 +327,42 @@ impl BroadcastingSoftwareLogic for Obsv5 {
     }
 
     async fn stop_streaming(&self) -> Result<(), error::Error> {
-        let connection = self.connection.lock().await;
+        const MAX_ATTEMPTS: usize = 4;
+        const INITIAL_RETRY_DELAY: Duration = Duration::from_millis(25);
 
-        let client = connection
-            .as_ref()
-            .ok_or(error::Error::UnableInitialConnection)?;
+        let mut last_error = None;
+        let mut retry_delay = INITIAL_RETRY_DELAY;
 
-        Ok(client.streaming().stop().await?)
+        for attempt in 1..=MAX_ATTEMPTS {
+            let stop_result = {
+                let connection = self.connection.lock().await;
+
+                match connection.as_ref() {
+                    Some(client) => client.streaming().stop().await.map_err(error::Error::from),
+                    None => Err(error::Error::UnableInitialConnection),
+                }
+            };
+
+            match stop_result {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    warn!(
+                        %e,
+                        attempt,
+                        MAX_ATTEMPTS,
+                        "Unable to stop stream, retrying"
+                    );
+                    last_error = Some(e);
+
+                    if attempt < MAX_ATTEMPTS {
+                        tokio::time::sleep(retry_delay).await;
+                        retry_delay = retry_delay.saturating_mul(2);
+                    }
+                }
+            }
+        }
+
+        Err(last_error.unwrap())
     }
 
     async fn fix(&self) -> Result<(), error::Error> {


### PR DESCRIPTION
I've noticed that in rare cases after raid, the obs stream didn't stop.

Here's one of these instances - relevant obs + noalbs logs interleaved:
![image](https://github.com/user-attachments/assets/03ebc63c-91e1-4b98-8b53-18c49a10f37b)

Seems like when noalbs tried to stop the stream, it found a dead? websocket, and reestablished the websocket immediately.
However, the obs stream stop command was not issued again.

Please have a look at this changeset - I've introduced a simple retry mechanism in  the stop command. 
I'm not sure if the changeset is technically ok though - not a rust dev.

While other places might benefit from a retry as well, I think the stop call might be the most important one.